### PR TITLE
improve customercare-mcp-builder skill description for better agent matching

### DIFF
--- a/skills/customercare-mcp-builder/SKILL.md
+++ b/skills/customercare-mcp-builder/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: customercare-mcp-builder
-description: Build MCP servers for customer care agents following Watson Orchestrate specifications. Guides agents through tool creation, transaction patterns, authentication, widgets, and context management with strict adherence to reference specifications. Use when creating customer care MCP servers.
+description: >-
+  Build MCP servers for customer care agents following Watson Orchestrate specifications. Guides through tool creation, transaction patterns, authentication, widgets, and context management with strict adherence to reference specs. Use when creating customer care MCP servers, building Watson Orchestrate tools, implementing MCP transaction patterns, or when the user says "create MCP server", "Watson Orchestrate tool", "customer care agent".
 ---
 
 # CustomerCare MCP Server Builder


### PR DESCRIPTION
hey @IBM, thanks for open-sourcing the watsonx Orchestrate ADK. really like the structured approach to building customer care MCP servers. kudos on passing `145` stars! just starred it.

ran your customercare-mcp-builder skill through some evals and noticed a few things that were pretty quick to improve (moving from `~67%` to `~78%` agent performance):

- expanded description with trigger terms like _create MCP server_, _Watson Orchestrate tool_, _customer care agent_ for better agent matching

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `3` skills here, if you want to do it yourself, spin up Claude Code and run `tessl skill review`. alternatively, let me know if you'd like an automatic review in your repo via GitHub Actions. it doesn't require signup, and this means you and your contributors get an instant quality signal before you have to review yourself.